### PR TITLE
Add raw examples to affconvert man page, remove E01 reference in readme

### DIFF
--- a/README
+++ b/README
@@ -30,7 +30,6 @@ forensic information. Using these tools you can:
 
    - raw or "dd" 
    - splitraw (in which a single image is split between mulitple files)
-   - EnCase or "E01" format
    - AFF format (in which the entire disk image is stored in a single file.)
    - AFD format (in which a disk image is stored in mulitple AFF files
      stored in a single directory.)

--- a/man/affconvert.1
+++ b/man/affconvert.1
@@ -78,7 +78,7 @@ Use 'ext' for the raw \fIfiles\fP (default is raw). Implies in \fB-r\fP.
 .TP
 .B
 \fB-r\fP
-Force raw output.
+Generate raw output.
 .RE
 .PP
 Dangerous input \fIoptions\fP:
@@ -104,11 +104,26 @@ Convert file1.raw to file1.aff:
 
 .fam T
 .fi
+Convert file1.aff to file1.raw:
+.PP
+.nf
+.fam C
+    $ affconvert -r file1.aff
+
+.fam T
+.fi
 Batch convert \fIfiles\fP:
 .PP
 .nf
 .fam C
     $ affconvert file1.raw file2.raw file3.raw
+
+.fam T
+.fi
+.PP
+.nf
+.fam C
+    $ affconvert -r file1.aff file2.aff file3.aff
 
 .fam T
 .fi


### PR DESCRIPTION
As discussed in #3.

I changed the wording in the man page from "force" to "generate", which might make it a little clearer, and then I added a couple of examples for converting to raw based on the existing aff examples.  