### PR TITLE
Allow macOS since FUSE for macOS is compatible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -238,10 +238,6 @@ AC_ARG_ENABLE(fuse,
 if test "x${enable_fuse}" = "xyes" ; then
   AC_MSG_NOTICE([FUSE requested])
   CPPFLAGS="-D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=26 $CPPFLAGS"
-  if test `uname -s` = Darwin ; then
-    AC_MSG_NOTICE([FUSE IS NOT SUPPORTED ON MACOS])
-    enable_fuse=no
-  fi
   AC_CHECK_HEADER([fuse.h],,
     AC_MSG_NOTICE([fuse.h not found; Disabling FUSE support.])
     enable_fuse=no)


### PR DESCRIPTION
`affuse` also works well on macOS with FUSE for macOS, so please allow to build on macOS with FUSE.