### PR TITLE
Add pkg-config check for macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -252,7 +252,7 @@ AS_IF([test "x$enable_fuse" != xno],
    AS_IF([test `uname -s` = Darwin && test "x$have_fuse" != "xyes"],
     [m4_ifdef([PKG_CHECK_MODULES],
       [PKG_CHECK_MODULES([FUSE], [fuse],
-        [have_fuse=yes])])]
+        [have_fuse=yes])])])
    AS_IF([test "x$enable_fuse" != xcheck && test "x$have_fuse" = xno],
     [AC_MSG_FAILURE([--enable-fuse was given but test for fuse failed])])])
 enable_fuse=$have_fuse

--- a/configure.ac
+++ b/configure.ac
@@ -252,7 +252,8 @@ AS_IF([test "x$enable_fuse" != xno],
    AS_IF([test `uname -s` = Darwin && test "x$have_fuse" != "xyes"],
     [m4_ifdef([PKG_CHECK_MODULES],
       [PKG_CHECK_MODULES([FUSE], [fuse],
-        [have_fuse=yes])])])
+        [have_fuse=yes],
+        [:])])])
    AS_IF([test "x$enable_fuse" != xcheck && test "x$have_fuse" = xno],
     [AC_MSG_FAILURE([--enable-fuse was given but test for fuse failed])])])
 enable_fuse=$have_fuse

--- a/configure.ac
+++ b/configure.ac
@@ -247,7 +247,12 @@ AS_IF([test "x$enable_fuse" != xno],
   [CPPFLAGS="-D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=26 $CPPFLAGS"
    AC_CHECK_HEADER([fuse.h],
     [AC_CHECK_LIB([fuse], [fuse_version],
-      [have_fuse=yes])])
+      [FUSE_LIBS=-lfuse
+       have_fuse=yes])])
+   AS_IF([test `uname -s` = Darwin && test "x$have_fuse" != "xyes"],
+    [m4_ifdef([PKG_CHECK_MODULES],
+      [PKG_CHECK_MODULES([FUSE], [fuse],
+        [have_fuse=yes])])]
    AS_IF([test "x$enable_fuse" != xcheck && test "x$have_fuse" = xno],
     [AC_MSG_FAILURE([--enable-fuse was given but test for fuse failed])])])
 enable_fuse=$have_fuse
@@ -257,8 +262,7 @@ AS_IF([test "x${enable_fuse}" = "xyes"],
   [AC_SUBST(FUSE_LIBS)
    AC_SUBST(FUSE_CFLAGS)
    AC_DEFINE([USE_FUSE],1,[Use FUSE to mount AFF images])
-   AFFUSE_BIN='affuse$(EXEEXT)'
-   FUSE_LIBS=-lfuse])
+   AFFUSE_BIN='affuse$(EXEEXT)'])
 AC_SUBST(AFFUSE_BIN)
 AM_PROG_CC_C_O			dnl for affuse
 ##


### PR DESCRIPTION
FUSE for macOS is compatible with Linux's implementation,
but it has a non standard library name (-losxfuse)
and header path (<osxfuse/fuse.h>) for the historic reason.
On macOS, using pkg-config is better to detect osxfuse properly.

pkg-config is used if the platform is macOS and pkg-config exists.
Therefore, no backward compatibility breakage should be present.