### PR TITLE
Do not force include and library dir in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,11 +34,11 @@ ACX_PTHREAD()
 if test x"${cross_compiling}" = "xno" ; then
   # Bring additional directories where things might be found into our
   # search path. I don't know why autoconf doesn't do this by default
-  for spfx in /usr/local /opt/local /sw ${prefix} ; do
+  for spfx in ${prefix} /sw /opt/local /usr/local ; do
     AC_MSG_NOTICE([checking ${spfx}/include])
     if test -d ${spfx}/include; then
-        CPPFLAGS="-I${spfx}/include $CPPFLAGS"
-        LDFLAGS="-L${spfx}/lib $LDFLAGS"
+        CPPFLAGS="$CPPFLAGS -I${spfx}/include"
+        LDFLAGS="$LDFLAGS -L${spfx}/lib"
         AC_MSG_NOTICE([ *** ADDING ${spfx}/include to CPPFLAGS *** ])
         AC_MSG_NOTICE([ *** ADDING ${spfx}/lib to LDFLAGS *** ])
     fi


### PR DESCRIPTION
Forcing the include and library path is not good when the user
has a multiple prefix (e.g. /opt/local and /usr/local) for some reason.
This situation is typical for macOS (MacPorts and Homebrew).

By this change, user-specified ones are prefered over guessed prefixes.
This behavior is more straightforward because the user can have the control
of what header and library is to be linked.