### PR TITLE
Recover to link with libexpat and lib curl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -127,8 +127,8 @@ AC_ARG_WITH([expat],
 have_expat=no
 AS_IF([test "x$with_expat" != xno],
   [AC_CHECK_HEADER([expat.h],
-    [AC_CHECK_LIB([expat], [XML_ParserCreate],
-      [have_expat=yes])])
+    [AC_CHECK_LIB([expat], [XML_ParserCreate])])
+   have_expat=${ac_cv_lib_expat_XML_ParserCreate-no}
    AS_IF([test "x$with_expat" != xcheck && test "x$have_expat" = xno],
     [AC_MSG_FAILURE([--with-expat was given but test for expat failed])])])
 
@@ -146,8 +146,8 @@ AC_ARG_WITH([curl],
 have_curl=no
 AS_IF([test "x$with_curl" != xno],
   [AC_CHECK_HEADER([curl/curl.h],
-    [AC_CHECK_LIB([curl], [curl_global_init],
-      [have_curl=yes])])
+    [AC_CHECK_LIB([curl], [curl_global_init],,)],)
+   have_curl=${ac_cv_lib_curl_curl_global_init-no}
    AS_IF([test "x$with_curl" != xcheck && test "x$have_curl" = xno],
     [AC_MSG_FAILURE([--with-curl was given but test for curl failed])])])
 


### PR DESCRIPTION
I apologize that #14 breaks the build: that never links with curl and expat.

This was due to my misunderstandings of the behavior of `AC_CHECK_LIB`.

AC_CHECK_LIB adds the -l<library> to LIBS and defines HAVE_<library> when the
third argument is empty.

This change recovers that behavior and now links with expat and curl correctly.

## Related
* #17