### PR TITLE
Use DESTDIR for packaging

### DIFF
--- a/pyaff/Makefile.am
+++ b/pyaff/Makefile.am
@@ -11,6 +11,6 @@ install-exec-local:
 	cd $(srcdir) && $(PYTHON) setup.py \
 		build --build-base $(abs_builddir)/build \
 		egg_info --egg-base $(abs_builddir) \
-		install --prefix $(prefix) --single-version-externally-managed --record=$(abs_builddir)/installed.txt \
+		install --prefix $(DESTDIR)$(prefix) --single-version-externally-managed --record=$(abs_builddir)/installed.txt \
 		bdist_egg --dist-dir $(abs_builddir)/dist
 endif


### PR DESCRIPTION
This allows to properly package python module