### PR TITLE
Fix incrementing in vnode_split_raw.cpp for comment consistnecy

### DIFF
--- a/lib/vnode_split_raw.cpp
+++ b/lib/vnode_split_raw.cpp
@@ -139,7 +139,7 @@ int split_raw_increment_fname (char *fn)
     }
 
     /* Increment */
-    if(incval(ext[2],10)){
+    if(incval(ext[2],36)){
 	if(incval(ext[1],36)){
 	    if(incval(ext[0],36)){
 		return EINVAL;


### PR DESCRIPTION
In vnode_split_raw.cpp the incrementing of extensions went
A09 -> A10.  The comments however indicate the incrementing
should go A09 -> A0A.  This commit changes the code to make
the incrementing consistent with what is described in the
code's comments.

Signed-off-by: Jason Dossett <jdossett@utdallas.edu>