### PR TITLE
fix handle double close problem

### DIFF
--- a/lib/vnode_split_raw.cpp
+++ b/lib/vnode_split_raw.cpp
@@ -205,6 +205,7 @@ static int split_raw_open_internal(AFFILE *af, uint64_t *image_size)
     if (fstat (fd, &sb) != 0) {
       (*af->error_reporter)("split_raw_open_internal: fstat(%s): ",af->fname);
 	close (fd);
+	srp->fds[0] = 0;
 	return -1;
     }
 


### PR DESCRIPTION
srp->fds[0] still keep the handle thought it had been closed.
in this case,closing srp->fds[0]  at split_raw_close function must raise Exception.