### PR TITLE
Add a CI test for GitHub

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -1,0 +1,27 @@
+name: full-check
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install_dependencies
+      run: sudo apt install chrpath libcurl4-openssl-dev libexpat1-dev libfuse-dev libssl-dev openssl zlib1g-dev
+    - name: first_build
+      run: |
+           ./bootstrap.sh
+           ./configure
+           make
+           sudo make install
+           sudo make uninstall
+           make distclean
+    - name: second_build
+      run: |
+           ./bootstrap.sh
+           ./configure
+           make
+           sudo make install


### PR DESCRIPTION
It will run after each push to test an initial build, install and uninstall. After this, a distclean and a second build and install will run to test if these actions execute twice. Any error in source code will break the build and invalidate the CI test.

These tests also will show warnings when compiling.
